### PR TITLE
Missing check for Distribution.tests_require attribute

### DIFF
--- a/src/setuptools_lint/setuptools_command.py
+++ b/src/setuptools_lint/setuptools_command.py
@@ -118,7 +118,7 @@ class PylintCommand(setuptools.Command):
         if self.distribution.install_requires:
             self.distribution.fetch_build_eggs(self.distribution.install_requires)
 
-        if self.distribution.tests_require:
+        if hasattr(self.distribution, "tests_require"):
             self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
         if self.lint_packages:


### PR DESCRIPTION
Tests require does not appear to be a default/given attribute of the setuptools Distribution class. When this does not exist the check will fail.